### PR TITLE
feat(release-test)!: Update configurations to use release-test compon…

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,33 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: .release-please-config.json
+          manifest-file: .release-please-manifest.json
+      # Optionally trigger the build workflow when a new release is created
+      - name: Trigger build workflow for new releases
+        if: ${{ steps.release.outputs.releases_created }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const releasedComponents = JSON.parse('${{ steps.release.outputs.releases_created_json }}');
+            console.log('New releases created:', releasedComponents);
+
+            // The full tags are available in the releases_created_json output
+            // You can use these to trigger specific builds for each released component

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,0 +1,114 @@
+{
+  "packages": {
+  "crates/astria-cli": {
+  "component": "cli",
+  "release-type": "rust",
+  "tag-separator": "-v",
+  "package-name": "astria-cli",
+  "changelog-path": "crates/astria-cli/CHANGELOG.md",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true
+  },
+  "crates/astria-conductor": {
+  "component": "conductor",
+  "release-type": "rust",
+  "tag-separator": "-v",
+  "package-name": "astria-conductor",
+  "changelog-path": "crates/astria-conductor/CHANGELOG.md",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true
+  },
+  "crates/astria-composer": {
+  "component": "composer",
+  "release-type": "rust",
+  "tag-separator": "-v",
+  "package-name": "astria-composer",
+  "changelog-path": "crates/astria-composer/CHANGELOG.md",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true
+  },
+  "crates/astria-sequencer": {
+  "component": "sequencer",
+  "release-type": "rust",
+  "tag-separator": "-v",
+  "package-name": "astria-sequencer",
+  "changelog-path": "crates/astria-sequencer/CHANGELOG.md",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true
+  },
+  "crates/astria-sequencer-relayer": {
+  "component": "sequencer-relayer",
+  "release-type": "rust",
+  "tag-separator": "-v",
+  "package-name": "astria-sequencer-relayer",
+  "changelog-path": "crates/astria-sequencer-relayer/CHANGELOG.md",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true
+  },
+  "crates/astria-bridge-withdrawer": {
+  "component": "bridge-withdrawer",
+  "release-type": "rust",
+  "tag-separator": "-v",
+  "package-name": "astria-bridge-withdrawer",
+  "changelog-path": "crates/astria-bridge-withdrawer/CHANGELOG.md",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true
+  },
+  "crates/astria-auctioneer": {
+  "component": "auctioneer",
+  "release-type": "rust",
+  "tag-separator": "-v",
+  "package-name": "astria-auctioneer",
+  "changelog-path": "crates/astria-auctioneer/CHANGELOG.md",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true
+  }
+  },
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "plugins": [
+  "cargo-workspace"
+  ],
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "release-type": "rust",
+  "include-component-in-tag": true,
+  "tag-separator": "-v",
+  "changelog-sections": [
+  {
+  "type": "feat",
+  "section": "Features",
+  "hidden": false
+  },
+  {
+  "type": "fix",
+  "section": "Bug Fixes",
+  "hidden": false
+  },
+  {
+  "type": "chore",
+  "section": "Miscellaneous",
+  "hidden": false
+  },
+  {
+  "type": "refactor",
+  "section": "Code Refactoring",
+  "hidden": false
+  },
+  {
+  "type": "docs",
+  "section": "Documentation",
+  "hidden": false
+  },
+  {
+  "type": "perf",
+  "section": "Performance Improvements",
+  "hidden": false
+  },
+  {
+  "type": "test",
+  "section": "Tests",
+  "hidden": false
+  }
+  ],
+  "separate-pull-requests": true
+  }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,9 +1,9 @@
 {
-  "crates/astria-cli": "0.0.0",
-  "crates/astria-conductor": "0.0.0",
-  "crates/astria-composer": "0.0.0",
-  "crates/astria-sequencer": "0.0.0",
-  "crates/astria-sequencer-relayer": "0.0.0",
-  "crates/astria-bridge-withdrawer": "0.0.0",
-  "crates/astria-auctioneer": "0.0.0"
+  "crates/astria-cli": "0.6.0",
+  "crates/astria-conductor": "1.1.0",
+  "crates/astria-composer": "1.0.1",
+  "crates/astria-sequencer": "2.0.0",
+  "crates/astria-sequencer-relayer": "1.0.1",
+  "crates/astria-bridge-withdrawer": "1.0.2",
+  "crates/astria-auctioneer": "0.0.1"
   }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,9 @@
+{
+  "crates/astria-cli": "0.0.0",
+  "crates/astria-conductor": "0.0.0",
+  "crates/astria-composer": "0.0.0",
+  "crates/astria-sequencer": "0.0.0",
+  "crates/astria-sequencer-relayer": "0.0.0",
+  "crates/astria-bridge-withdrawer": "0.0.0",
+  "crates/astria-auctioneer": "0.0.0"
+  }


### PR DESCRIPTION
Re-applying from old [PR](https://github.com/astriaorg/astria-release-test/pull/3)

This is just for testing -- I based it off of @warhod 's PR and thus the PR is back to that branch instead of main (for now).

This work is effectively what I had from my test repo + extra massage with claude.

Key points/goals:

- uses release-please to keep a rolling draft release
- auto generate diff changelogs based on conventional commit messages
- auto bumps rust component semver based on conventional commit
- auto bump chart component semver based on conventional commit

All of this needs testing. I am waiting on us getting our artifact builds working first before testing this.

Test cases to cover:
- Each type of conventional commit supported to different rust components
  - e.g. breaking changes should result in major version bump, etc.
- Changelogs should properly capture diffs since last release tag
- A rolling draft release should be auto-created every time something is merged to main
- Merging the actual release to main from draft should do all the things in one step.
- Ensure release binaries / docker images are still built and published
- ...
- ... there's probably more things to test. 